### PR TITLE
Add WordPress 4.9 CSS fix.

### DIFF
--- a/github-link.php
+++ b/github-link.php
@@ -159,7 +159,7 @@ function GHL_plugin_link( $actions, $plugin_file, $plugin_data, $context ) {
 
 /**
  * In WordPress 4.9, core introduced icons next to plugin on the update-code.php
- * page. This adds a new font-size to the psudo :before of 60px. This CSS line
+ * page. This adds a new font-size to the pseudo :before of 60px. This CSS line
  * fixes it for the plugin.php page.
  */
 function GHL_wp49_css_fix() {

--- a/github-link.php
+++ b/github-link.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name:       GitHub Link
-Version:           0.4.5
+Version:           0.4.6
 Plugin URI:        https://github.com/szepeviktor/github-link
 Description:       Displays GitHub link on the Plugins page given there is a <code>GitHub Plugin URI</code> plugin header.
 License:           The MIT License (MIT)
@@ -26,6 +26,7 @@ load_plugin_textdomain( 'github-link', false, dirname( __FILE__ ) . '/languages'
 add_filter( "extra_plugin_headers", "GHL_extra_headers" );
 add_filter( "plugin_action_links", "GHL_plugin_link", 10, 4 );
 add_filter( "network_admin_plugin_action_links", "GHL_plugin_link", 10, 4 );
+add_action( "admin_head-plugins.php", "GHL_wp49_css_fix" );
 
 function GHL_extra_headers( $extra_headers ) {
 
@@ -48,7 +49,7 @@ function GHL_plugin_link( $actions, $plugin_file, $plugin_data, $context ) {
         return $actions;
 
     $link_template = '<a href="%s" title="%s" target="_blank"><img src="%s" style="width: 16px; height: 16px; vertical-align:-3px;" height="16" width="16" alt="%s" />%s</a>';
-    $wp_link_template = '<a href="%s" title="%s" target="_blank"><span style="width: 16px; height: 16px; color:#2880A8; font-size:16px; vertical-align:-3px;" class="dashicons dashicons-wordpress"></span></a>';
+    $wp_link_template = '<a href="%s" title="%s" target="_blank"><span style="width: 16px; height: 16px; color:#2880A8; font-size:18px; vertical-align:-3px;" class="github-link dashicons dashicons-wordpress"></span></a>';
 
     $on_wporg = false;
     _maybe_update_plugins();
@@ -154,4 +155,26 @@ function GHL_plugin_link( $actions, $plugin_file, $plugin_data, $context ) {
     }
 
     return $actions;
+}
+
+/**
+ * In WordPress 4.9, core introduced icons next to plugin on the update-code.php
+ * page. This adds a new font-size to the psudo :before of 60px. This CSS line
+ * fixes it for the plugin.php page.
+ */
+function GHL_wp49_css_fix() {
+    global $wp_version;
+
+    if ( version_compare( $wp_version, '4.9', '>=' ) ) {
+        ?>
+        <style type="text/css">
+            .plugins .plugin-title .github-link.dashicons::before {
+                background-color: transparent;
+                box-shadow: none;
+                font-size: 16px;
+                color: inherit;
+            }
+        </style>
+        <?php
+    }
 }


### PR DESCRIPTION
In WordPress 4.9, core introduced icons next to plugin on the update-code.php page. This adds a new font-size to the pseudo :before of 60px. This CSS line fixes it for the plugin.php page.

_Testing in single site, and multisite_.